### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/process_names.py
+++ b/process_names.py
@@ -17,7 +17,7 @@ def parse_command_line(argv):
     
     parser.add_option("-o", "--out", action="store", 
                       type="string", dest="outfile", default=DEFAULT_OUTPUT,
-                      help="Output file in CSV (default: %s)" % DEFAULT_OUTPUT)
+                      help="Output file in CSV (default: {0!s})".format(DEFAULT_OUTPUT))
     parser.add_option("-c", "--column", action="store", 
                       type="string", dest="column", default="Name",
                       help="Column name file in CSV contains Name list (default: Name)")
@@ -27,12 +27,12 @@ def parse_command_line(argv):
     return parser.parse_args(argv)
 
 if __name__ == "__main__":
-    print "%s - r3 (2013/08/25)\n" % (os.path.basename(sys.argv[0]))    
+    print "{0!s} - r3 (2013/08/25)\n".format((os.path.basename(sys.argv[0])))    
 
     (options, args) = parse_command_line(sys.argv)
 
     if len(args) < 2:
-        print("Usage: %s [options] <input file>\n" % (sys.argv[0]))
+        print("Usage: {0!s} [options] <input file>\n".format((sys.argv[0])))
         sys.exit(-1)
    
     print("Processing and exporting, please wait...")


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:soodoku:clean-names?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:soodoku:clean-names?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
